### PR TITLE
proper table header spacing for 100 browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var SummaryReporter = function(baseReporterDecorator, config) {
 			this.writeCommonMsg(' all  ');
 		}
 		browsers.forEach(function(browser, i) {
-			this.writeCommonMsg(' '+  i + ' ');
+			this.writeCommonMsg((i < 10 && ' ') +  i + ' ');
 		}, this);
 		this.writeCommonMsg('\n');
 	}

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var SummaryReporter = function(baseReporterDecorator, config) {
 			this.writeCommonMsg(' all  ');
 		}
 		browsers.forEach(function(browser, i) {
-			this.writeCommonMsg((i < 10 && ' ') +  i + ' ');
+			this.writeCommonMsg((i < 10 ? ' ' : '') +  i + ' ');
 		}, this);
 		this.writeCommonMsg('\n');
 	}

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -161,4 +161,18 @@ describe('Summary reporter', function () {
 			chai.assert.doesNotThrow(function() { reporter.specSuccess(b1, {}); });
 		});
 	});
+
+  describe("many browsers", function() {
+		beforeEach(function() {
+			setupReporter({});
+		});
+
+    it ('should format >10 browsers correctly', function() {
+      reporter.printTableHeader(new Array(20).fill(undefined));
+      chai.assert.isTrue(writeOutput.includes(
+        ' 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19'),
+        'formats the header correctly');
+    });
+  });
+
 });

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -162,17 +162,18 @@ describe('Summary reporter', function () {
 		});
 	});
 
-  describe("many browsers", function() {
+	describe("many browsers", function() {
 		beforeEach(function() {
 			setupReporter({});
 		});
 
-    it ('should format >10 browsers correctly', function() {
-      reporter.printTableHeader(new Array(20).fill(undefined));
-      chai.assert.isTrue(writeOutput.includes(
-        ' 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19'),
-        'formats the header correctly');
-    });
-  });
+		it ('should format >10 browsers correctly', function() {
+			reporter.printTableHeader(new Array(20).fill(undefined));
+			chai.assert.isTrue(
+				writeOutput.includes(
+				' 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19'),
+				'formats the header correctly');
+		});
+	});
 
 });


### PR DESCRIPTION
This PR simply adjusts the spacing between the numbers in the header row for the table so that it can support up to 100 browsers.