### PR TITLE
Upgrade CI to current actions and versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
-        node: [20, 22, 24, 26]
+        node: [20, 22, 24]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,12 @@ jobs:
     name: NodeJS
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
-        node: [16, 18, 20, 22]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
+        node: [20, 22, 24, 26]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: yarn


### PR DESCRIPTION
Use current Node and Ubuntu versions for CI. Use current versions of Github actions.